### PR TITLE
SUB1-001 Todo api axios instance 의 header 에 autorization 추가

### DIFF
--- a/src/apis/todo.js
+++ b/src/apis/todo.js
@@ -6,7 +6,13 @@ const baseURL = `${BASE_URL}/todos`;
 
 const todoAxios = axios.create({
   baseURL,
-  headers: { Authorization: `Bearer ${getToken()}` }
+});
+
+todoAxios.interceptors.request.use(config => {
+  const newConfig = config;
+  newConfig.headers.Authorization = `Bearer ${getToken()}`;
+
+  return newConfig;
 });
 
 export const getTodos = async () => {

--- a/src/apis/todo.js
+++ b/src/apis/todo.js
@@ -6,12 +6,12 @@ const baseURL = `${BASE_URL}/todos`;
 
 const todoAxios = axios.create({
   baseURL,
+  headers: { Authorization: `Bearer ${getToken()}` }
 });
 
 export const getTodos = async () => {
   const { data } = await todoAxios({
     method: 'get',
-    headers: { Authorization: `Bearer ${getToken()}` },
   });
 
   return data;
@@ -21,7 +21,6 @@ export const createTodo = async todo => {
   const { data } = await todoAxios({
     method: 'post',
     data: { todo },
-    headers: { Authorization: `Bearer ${getToken()}` },
   });
 
   return data;
@@ -32,7 +31,6 @@ export const updateTodo = async ({ id, todo, isCompleted }) => {
     method: 'put',
     url: `/${id}`,
     data: { todo, isCompleted },
-    headers: { Authorization: `Bearer ${getToken()}` },
   });
 };
 
@@ -40,6 +38,5 @@ export const deleteTodo = async id => {
   await todoAxios({
     method: 'delete',
     url: `/${id}`,
-    headers: { Authorization: `Bearer ${getToken()}` },
   });
 };


### PR DESCRIPTION
 ## 변경 하고자 하는 이유 혹은 원인  
- Todo api 요청의 header 의 `authorization` 속성에 토큰 이 공통적으로 포함됨.

## 변경점
- interceptor 를 이용해 Todo api 요청의 header 에 authorization 추가

## 작업사항
```js
todoAxios.interceptors.request.use(config => {
  const newConfig = config;
  newConfig.headers.Authorization = `Bearer ${getToken()}`;

  return newConfig;
```

## 기타
- 공통 axios instance header 에 토큰 을 포함 하는 방식으로 해결하려 했으나, 로그인 직후 토큰을 불러들이지 못하는 버그 발생하여 interceptor 사용